### PR TITLE
chore: update actions versions to latest

### DIFF
--- a/.github/workflows/build_main.yaml
+++ b/.github/workflows/build_main.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pages: write
@@ -24,12 +24,12 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Build
         run: |
           docker run -v "$PWD:/workspace" -w "/workspace" ghcr.io/eodash/eodash_catalog:0.4.4 eodash_catalog -gp
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4
         with:
           folder: ./build
           branch: gh-pages

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,7 +17,7 @@ on:
 concurrency: preview-${{ github.ref }}
 jobs:
   preview_changed_files:
-    runs-on: ubuntu-latest 
+    runs-on: ubuntu-24.04 
     permissions:
       contents: write
       pages: write
@@ -26,7 +26,7 @@ jobs:
     name: Deploy changed-files
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: 'true'
           ref: ${{ github.event.pull_request.head.ref }}
@@ -51,7 +51,7 @@ jobs:
         if: github.event.action != 'closed' # skip the build if the PR has been closed, just  for cleanup
         name: changed-files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
       - name: Update Preview Catalog
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
@@ -63,14 +63,14 @@ jobs:
           docker run -v "$PWD:/workspace" -w "/workspace" ghcr.io/eodash/eodash_catalog:0.4.4 eodash_catalog -gp
       - if: steps.get_pr_commit_message.outputs.should_skip != 'true'
         name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1
         with:
           source-dir: ./build/
       -
         if: github.event.action != 'closed' && steps.get_pr_commit_message.outputs.should_skip != 'true'
         name: Find existing comment
         id: find-comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: github-actions
@@ -78,7 +78,7 @@ jobs:
       -
         if: github.event.action != 'closed' && steps.get_pr_commit_message.outputs.should_skip != 'true'
         name: Create or update preview comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |


### PR DESCRIPTION
FYI @elaineting-eda @pradeep-eda updating the github actions to latest versions and node 24 to remove CI warnings about forced migration to node 24 for GitHub runners on 3.6.26.

<img width="1452" height="167" alt="image" src="https://github.com/user-attachments/assets/678b10cc-01cb-46e4-82b9-ffb6c73abd85" />
